### PR TITLE
improve ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,10 +43,13 @@ jobs:
           - '1'
         os:
           - ubuntu-latest
-          - macOS-latest
           - windows-latest
         arch:
           - x64
+        include:
+          - version: '1'
+            os: macOS-latest
+            arch: aarch64
     steps:
       - uses: actions/checkout@v6
       - uses: julia-actions/setup-julia@v2
@@ -80,4 +83,4 @@ jobs:
           # 1. If the PR is from a fork, then no Codecov token is required.
           # 2. If the PR is NOT from a fork, then the Codecov token is required.
           token: ${{ secrets.CODECOV_TOKEN }}
-          fail_ci_if_error: true
+          fail_ci_if_error: false


### PR DESCRIPTION
move mac ci to aarch (only on version 1 since 1.6 doesn't support M1 mac).  Also set codecov to allow fail since it's flaky.